### PR TITLE
fix: resolve MkDocs strict build failures and Release Please token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/guides/cicd-pipelines.md
+++ b/docs/guides/cicd-pipelines.md
@@ -54,22 +54,22 @@ Every pipeline follows the same four-stage pattern:
 All examples are in `examples/pipelines/`:
 
 ### GitHub Actions
-- [Terraform](../../examples/pipelines/github-actions/deploy-terraform.yml.example)
-- [Bicep](../../examples/pipelines/github-actions/deploy-bicep.yml.example)
-- [Ansible](../../examples/pipelines/github-actions/deploy-ansible.yml.example)
-- [PowerShell](../../examples/pipelines/github-actions/deploy-powershell.yml.example)
+- [Terraform](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/github-actions/deploy-terraform.yml.example)
+- [Bicep](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/github-actions/deploy-bicep.yml.example)
+- [Ansible](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/github-actions/deploy-ansible.yml.example)
+- [PowerShell](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/github-actions/deploy-powershell.yml.example)
 
 ### GitLab CI
-- [Terraform](../../examples/pipelines/gitlab/deploy-terraform.gitlab-ci.yml.example)
-- [Bicep](../../examples/pipelines/gitlab/deploy-bicep.gitlab-ci.yml.example)
-- [Ansible](../../examples/pipelines/gitlab/deploy-ansible.gitlab-ci.yml.example)
-- [PowerShell](../../examples/pipelines/gitlab/deploy-powershell.gitlab-ci.yml.example)
+- [Terraform](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/gitlab/deploy-terraform.gitlab-ci.yml.example)
+- [Bicep](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/gitlab/deploy-bicep.gitlab-ci.yml.example)
+- [Ansible](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/gitlab/deploy-ansible.yml.example)
+- [PowerShell](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/gitlab/deploy-powershell.gitlab-ci.yml.example)
 
 ### Azure DevOps
-- [Terraform](../../examples/pipelines/azure-devops/deploy-terraform.yml.example)
-- [Bicep](../../examples/pipelines/azure-devops/deploy-bicep.yml.example)
-- [Ansible](../../examples/pipelines/azure-devops/deploy-ansible.yml.example)
-- [PowerShell](../../examples/pipelines/azure-devops/deploy-powershell.yml.example)
+- [Terraform](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/azure-devops/deploy-terraform.yml.example)
+- [Bicep](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/azure-devops/deploy-bicep.yml.example)
+- [Ansible](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/azure-devops/deploy-ansible.yml.example)
+- [PowerShell](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/pipelines/azure-devops/deploy-powershell.yml.example)
 
 ## Environment Promotion
 
@@ -80,7 +80,7 @@ staging → production
 - **Staging**: Auto-deploys on merge to `main` (or `develop` if using GitFlow)
 - **Production**: Requires manual approval via environment protection rules
 
-Use separate `config/variables.yml` per environment, or parameterize per the [example configs](../../examples/configs/).
+Use separate `config/variables.yml` per environment, or parameterize per the [example configs](https://github.com/AzureLocal/azurelocal-sofs-fslogix/tree/main/examples/configs/).
 
 ## Getting Started
 

--- a/docs/guides/secrets-management.md
+++ b/docs/guides/secrets-management.md
@@ -23,9 +23,9 @@ How to store and reference secrets for SOFS + FSLogix CI/CD pipelines.
 
 Detailed per-platform instructions:
 
-- [GitHub Secrets](../../examples/secrets/github-secrets.md) — Repo secrets, org secrets, OIDC setup
-- [GitLab Variables](../../examples/secrets/gitlab-variables.md) — Project/group variables, protected/masked flags
-- [Azure DevOps Variable Groups](../../examples/secrets/azure-devops-variable-groups.md) — Variable groups, service connections, Key Vault linking
+- [GitHub Secrets](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/secrets/github-secrets.md) — Repo secrets, org secrets, OIDC setup
+- [GitLab Variables](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/secrets/gitlab-variables.md) — Project/group variables, protected/masked flags
+- [Azure DevOps Variable Groups](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/secrets/azure-devops-variable-groups.md) — Variable groups, service connections, Key Vault linking
 
 ## Azure Key Vault Integration
 
@@ -39,7 +39,7 @@ domain:
   join_password: "keyvault://kv-platform-prod/domain-join-password"
 ```
 
-Each CI/CD platform can pull these at pipeline runtime. See [Key Vault Integration](../../examples/secrets/keyvault-integration.md) for per-platform details.
+Each CI/CD platform can pull these at pipeline runtime. See [Key Vault Integration](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/secrets/keyvault-integration.md) for per-platform details.
 
 ## OIDC / Workload Identity Federation (Recommended)
 
@@ -74,7 +74,7 @@ No `AZURE_CLIENT_SECRET` needed.
 
 ## Complete Variables Reference
 
-See [Variables Reference](../../examples/secrets/variables-reference.md) for a full table of every secret and variable name, which tools use it, and where to store it.
+See [Variables Reference](https://github.com/AzureLocal/azurelocal-sofs-fslogix/blob/main/examples/secrets/variables-reference.md) for a full table of every secret and variable name, which tools use it, and where to store it.
 
 ## Best Practices
 


### PR DESCRIPTION
- Convert 12 broken relative links in cicd-pipelines.md to GitHub URLs
- Convert 5 broken relative links in secrets-management.md to GitHub URLs
- Links pointed outside docs/ dir which MkDocs cannot resolve
- Use GITHUB_TOKEN instead of missing RELEASE_PLEASE_TOKEN secret