### PR TITLE
feat(ansible): end-to-end playbooks, Option A/B, anti-affinity, molecule (#63)

### DIFF
--- a/src/ansible/.ansible-lint
+++ b/src/ansible/.ansible-lint
@@ -1,0 +1,15 @@
+---
+# .ansible-lint configuration
+# See https://ansible.readthedocs.io/projects/lint/configuring/
+
+profile: production
+
+exclude_paths:
+  - molecule/
+
+skip_list:
+  - command-instead-of-module   # az CLI has no native module equivalent for stack-hci-vm
+  - no-changed-when             # many az CLI tasks have custom changed_when logic
+
+warn_list:
+  - experimental

--- a/src/ansible/README.md
+++ b/src/ansible/README.md
@@ -4,83 +4,83 @@
 
 ## Overview
 
-Two-playbook approach for deploying and configuring the SOFS guest cluster:
+End-to-end Ansible deployment covering Phases 1–11 of the SOFS/FSLogix solution.
+Supports all 10 scenarios via `sofs_guest_volume_layout` (Option A / B) and
+resiliency settings.
 
-| Playbook | Target | Purpose |
-|----------|--------|---------|
-| `deploy-azure-resources.yml` | `localhost` | Creates Azure resources via `az` CLI (VMs, NICs, disks, witness) |
-| `configure-sofs-cluster.yml` | `sofs_nodes` (WinRM) | Configures guest OS: clustering, S2D, SOFS role, SMB share |
+| Playbook | Target | Phases |
+|----------|--------|--------|
+| `deploy-azure-resources.yml` | `localhost` | 1 (Azure resources) + 2 (domain join) |
+| `configure-sofs-cluster.yml` | `sofs_nodes` + `host_cluster` | 3 (anti-affinity) + 5–9c + 11 (validation) |
+| `configure-fslogix.yml` | `avd_session_hosts` | FSLogix registry settings |
+| `configure-sofs.yml` | `sofs_nodes` | SMB share optimisation |
 
 ## Prerequisites
 
-- Python packages: `pywinrm`, `requests-kerberos` (for WinRM/Kerberos)
+- Python packages: `pywinrm`, `requests-kerberos`
 - Azure CLI authenticated (`az login`)
-- `ansible.windows` collection installed:
+- Install required collections:
   ```bash
-  ansible-galaxy collection install ansible.windows
+  ansible-galaxy collection install -r requirements.yml
   ```
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `inventory.yml` | Host inventory + all SOFS variables |
-| `deploy-azure-resources.yml` | Playbook 1: Azure resource deployment (localhost) |
-| `configure-sofs-cluster.yml` | Playbook 2: Guest cluster config (WinRM to SOFS VMs) |
-| `README.md` | This file |
+| `requirements.yml` | Pinned Ansible collection versions |
+| `.ansible-lint` | Linter configuration |
+| `inventory/inventory.yml` | Full inventory with all SOFS variables |
+| `inventory/hosts.example.yml` | Minimal host template |
+| `playbooks/*.yml` | Deployment playbooks |
+| `molecule/` | Molecule test scenarios |
 
 ## Usage
 
-### 1. Configure Inventory
+### 1. Install Collections
 
-Copy `inventory.yml` and update:
+```bash
+ansible-galaxy collection install -r requirements.yml
+```
+
+### 2. Configure Inventory
+
+Copy `inventory/inventory.yml` and update:
 - Azure subscription ID and resource IDs
-- VM IPs in the `sofs_nodes` group
-- WinRM credentials (use `ansible-vault` for passwords)
+- VM IPs in `sofs_nodes`, host IPs in `host_cluster`
+- Vault-encrypted credentials
 
-### 2. Deploy Azure Resources
+### 3. Deploy Azure Resources + Domain Join
 
 ```bash
-# Dry run
-ansible-playbook -i inventory.yml deploy-azure-resources.yml --check
-
-# Deploy
-ansible-playbook -i inventory.yml deploy-azure-resources.yml \
-  --extra-vars "sofs_admin_password=<password>"
+ansible-playbook -i inventory/inventory.yml playbooks/deploy-azure-resources.yml \
+  --extra-vars "sofs_admin_password=<password> sofs_domain_join_password=<password>"
 ```
 
-### 3. Configure Guest Cluster
-
-After VMs are deployed and domain-joined:
+### 4. Configure Guest Cluster (Phases 3, 5–11)
 
 ```bash
-# Dry run
-ansible-playbook -i inventory.yml configure-sofs-cluster.yml --check
-
-# Configure
-ansible-playbook -i inventory.yml configure-sofs-cluster.yml \
+ansible-playbook -i inventory/inventory.yml playbooks/configure-sofs-cluster.yml \
   --extra-vars "sofs_witness_key=<witness-storage-key>"
 ```
 
-### 4. End-to-End
+### 5. Configure FSLogix on AVD Hosts
 
 ```bash
-# Full deployment (both playbooks)
-ansible-playbook -i inventory.yml deploy-azure-resources.yml \
-  --extra-vars "sofs_admin_password=<password>"
+ansible-playbook -i inventory/inventory.yml playbooks/configure-fslogix.yml
+```
 
-# Wait for VMs to be domain-joined, then:
-ansible-playbook -i inventory.yml configure-sofs-cluster.yml \
-  --extra-vars "sofs_witness_key=<witness-storage-key>"
+## Testing
+
+```bash
+# Lint
+ansible-lint src/ansible/
+
+# Molecule (syntax validation)
+cd src/ansible && molecule test
 ```
 
 ## Variable Mapping
 
-All variables in `inventory.yml` correspond to `wsfc_sofs_*` entries in `configs/variables/assets/master-registry.yaml`.
-
-## References
-
-- [Bicep deployment](../bicep/) — Subscription-scope Bicep wrapper
-- [Terraform deployment](../terraform/) — azapi provider module
-- [PowerShell scripts](../powershell/) — Azure CLI deploy + guest OS configuration
-- [SOFS Deployment Guide](../SOFS-Deployment-Guide.md)
+All `sofs_*` variables in inventory correspond to entries in
+`config/variables.yml` and the Terraform inventory template.

--- a/src/ansible/inventory/hosts.example.yml
+++ b/src/ansible/inventory/hosts.example.yml
@@ -12,23 +12,27 @@ all:
     ansible_winrm_server_cert_validation: ignore
 
   children:
+    # Azure Local host cluster nodes (for Phase 3 anti-affinity)
+    host_cluster:
+      hosts:
+        azl-node-01:
+          ansible_host: 10.0.0.1
+        azl-node-02:
+          ansible_host: 10.0.0.2
+
     sofs_nodes:
       hosts:
-        node01.iic.local:
+        SOFS-01:
           ansible_host: 192.168.1.11
-        node02.iic.local:
+        SOFS-02:
           ansible_host: 192.168.1.12
       vars:
-        sofs_name: "SOFS01"
-        share_name: "FSLogixProfiles"
-        share_path: "C:\\ClusterStorage\\Volume1\\FSLogixProfiles"
-        avd_users_group: "AVD-Users"
+        sofs_access_point: "FSLogixSOFS"
+        sofs_share_name: "FSLogix"
 
     avd_session_hosts:
       hosts:
-        avd-host-01.iic.local:
+        avd-host-01:
           ansible_host: 192.168.2.11
-        avd-host-02.iic.local:
+        avd-host-02:
           ansible_host: 192.168.2.12
-      vars:
-        fslogix_vhd_location: "\\\\SOFS01\\FSLogixProfiles"

--- a/src/ansible/inventory/inventory.yml
+++ b/src/ansible/inventory/inventory.yml
@@ -4,7 +4,7 @@
 # Update host IPs and credentials for your environment.
 # Use ansible-vault to encrypt sensitive values.
 #
-# EXAMPLE COMPANY: Infinite Improbability Corp (improbability.cloud)
+# Supports all 10 SOFS scenarios via sofs_guest_volume_layout + resiliency.
 # =============================================================================
 
 all:
@@ -15,13 +15,17 @@ all:
     sofs_location: "eastus"
 
     # --- Azure Local infrastructure IDs ---
-    sofs_custom_location_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-azl-eus-01/providers/Microsoft.ExtendedLocation/customLocations/iic-azl-eus-cl"
-    sofs_logical_network_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-azl-eus-01/providers/Microsoft.AzureStackHCI/logicalNetworks/iic-compute-network"
-    sofs_gallery_image: "img-iic-ws2025-datacenter-g2-v1"
-    sofs_storage_path_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-azl-eus-01/providers/Microsoft.AzureStackHCI/storageContainers/iic-azl-eus-storage"
+    sofs_custom_location_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-azl-eus-01/providers/Microsoft.ExtendedLocation/customLocations/azl-eus-cl"
+    sofs_logical_network_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-azl-eus-01/providers/Microsoft.AzureStackHCI/logicalNetworks/compute-network"
+    sofs_gallery_image_id: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-azl-eus-01/providers/Microsoft.AzureStackHCI/galleryImages/ws2025-datacenter-g2"
+    # Per-VM storage path mapping (spreads I/O across CSV volumes)
+    sofs_storage_path_ids:
+      "01": "/subscriptions/.../storageContainers/csv-01"
+      "02": "/subscriptions/.../storageContainers/csv-02"
+      "03": "/subscriptions/.../storageContainers/csv-03"
 
     # --- VM configuration ---
-    sofs_vm_prefix: "IIC-SOFS"
+    sofs_vm_prefix: "SOFS"
     sofs_vm_count: 3
     sofs_vm_processors: 4
     sofs_vm_memory_mb: 8192
@@ -33,9 +37,14 @@ all:
     sofs_data_disk_size_gb: 1024
 
     # --- Cloud witness ---
-    sofs_cloud_witness_name: "stsofswitnessiic01"
+    sofs_cloud_witness_name: "stsofswitness01"
 
-    # --- Guest cluster configuration ---
+    # --- Architecture choices (determines which of the 10 scenarios) ---
+    sofs_guest_volume_layout: "option_a"   # option_a | option_b
+    sofs_host_resiliency: "two_way"        # two_way | three_way
+    sofs_guest_resiliency: "two_way"       # two_way | three_way
+
+    # --- Guest cluster configuration (Option A) ---
     sofs_cluster_name: "SOFS-Cluster"
     sofs_cluster_ip: "192.168.211.60"
     sofs_access_point: "FSLogixSOFS"
@@ -43,10 +52,61 @@ all:
     sofs_s2d_volume_name: "FSLogixData"
     sofs_s2d_volume_size: "5632GB"
     sofs_s2d_data_copies: 2
-    sofs_domain_fqdn: "iic.local"
-    sofs_domain_netbios: "IMPROBABLE"
+    sofs_sofs_role_name: "FSLogixSOFS"
+    sofs_s2d_pool_name: "S2D on SOFS-Cluster"
+    sofs_smb_encryption: true
+    sofs_access_point_ip: "192.168.211.61"
+
+    # --- Option B: multiple volumes/shares (uncomment when layout = option_b) ---
+    # sofs_shares:
+    #   - name: "Profiles"
+    #     volume: "Profiles"
+    #   - name: "ODFC"
+    #     volume: "ODFC"
+    #   - name: "AppData"
+    #     volume: "AppData"
+    # sofs_s2d_volumes:
+    #   - name: "Profiles"
+    #     size_gb: 33485
+    #     data_copies: 2
+    #   - name: "ODFC"
+    #     size_gb: 21299
+    #     data_copies: 2
+    #   - name: "AppData"
+    #     size_gb: 6144
+    #     data_copies: 2
+
+    # --- Domain join ---
+    sofs_domain_fqdn: "contoso.local"
+    sofs_domain_netbios: "CONTOSO"
+    sofs_domain_join_account: "svc.domainjoin"
+    # sofs_domain_join_password: !vault | (use ansible-vault encrypt_string)
+    sofs_domain_ou_nodes: "OU=SOFS-Cluster,OU=Servers,DC=contoso,DC=local"
+    sofs_domain_ou_cluster: "OU=SOFS-Cluster,OU=Servers,DC=contoso,DC=local"
+
+    # --- Anti-affinity ---
     sofs_anti_affinity_rule: "SOFS-AntiAffinity"
     sofs_azl_cluster_name: "AzLocalCluster"
+
+    # --- Permissions ---
+    sofs_permissions_admin_group: "Domain Admins"
+    sofs_permissions_users_group: "AVD-Users"
+    sofs_permissions_avd_users_group: "AVD-Users"
+
+    # --- FSLogix ---
+    sofs_fslogix_enabled: true
+    sofs_fslogix_profile_size_mb: 30000
+    sofs_fslogix_volume_type: "VHDX"
+    sofs_cloud_cache_enabled: false
+    # sofs_cloud_cache_azure_provider: ""
+
+    # --- DNS ---
+    sofs_dns_servers:
+      - "10.0.1.10"
+      - "10.0.1.11"
+
+    # --- Tags ---
+    sofs_tags: "project=SOFS workload=FSLogix solution=sofs-azure-local"
 
     # --- WinRM connection for Windows targets ---
     ansible_connection: winrm
@@ -55,11 +115,28 @@ all:
     ansible_port: 5986
 
   children:
+    # Azure Local host cluster nodes (for Phase 3 anti-affinity)
+    host_cluster:
+      hosts:
+        azl-node-01:
+          ansible_host: 10.0.0.1
+        azl-node-02:
+          ansible_host: 10.0.0.2
+
+    # SOFS guest VMs
     sofs_nodes:
       hosts:
-        IIC-SOFS-01:
+        SOFS-01:
           ansible_host: 192.168.211.51
-        IIC-SOFS-02:
+        SOFS-02:
           ansible_host: 192.168.211.52
-        IIC-SOFS-03:
+        SOFS-03:
           ansible_host: 192.168.211.53
+
+    # AVD session hosts (for FSLogix registry config)
+    avd_session_hosts:
+      hosts:
+        avd-host-01:
+          ansible_host: 192.168.2.11
+        avd-host-02:
+          ansible_host: 192.168.2.12

--- a/src/ansible/molecule/default/converge.yml
+++ b/src/ansible/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+# Molecule converge playbook — verifies that playbooks parse and
+# variable references resolve against the test inventory.
+# No real Windows hosts are contacted (ansible_connection: local).
+
+- name: "Verify deploy-azure-resources.yml syntax"
+  ansible.builtin.import_playbook: ../../playbooks/deploy-azure-resources.yml
+  vars:
+    # Override passwords for syntax-only validation
+    sofs_admin_password: "TestPass123!"
+    sofs_domain_join_password: "TestPass123!"
+
+- name: "Verify configure-fslogix.yml syntax"
+  ansible.builtin.import_playbook: ../../playbooks/configure-fslogix.yml

--- a/src/ansible/molecule/default/molecule.yml
+++ b/src/ansible/molecule/default/molecule.yml
@@ -1,0 +1,89 @@
+---
+# Molecule test scenario for SOFS Ansible playbooks.
+# Uses the "delegated" driver — no real Windows VMs are provisioned.
+# Validates YAML syntax, variable references, and ansible-lint compliance.
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ../../requirements.yml
+
+driver:
+  name: delegated
+  options:
+    managed: false
+
+platforms:
+  - name: sofs-test-01
+    groups:
+      - sofs_nodes
+      - all
+
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      all:
+        vars:
+          sofs_subscription_id: "00000000-0000-0000-0000-000000000000"
+          sofs_resource_group: "rg-sofs-test"
+          sofs_location: "eastus"
+          sofs_custom_location_id: "/subscriptions/00000000/resourceGroups/rg-test/providers/Microsoft.ExtendedLocation/customLocations/test-cl"
+          sofs_logical_network_id: "/subscriptions/00000000/resourceGroups/rg-test/providers/Microsoft.AzureStackHCI/logicalNetworks/test-net"
+          sofs_gallery_image_id: "/subscriptions/00000000/resourceGroups/rg-test/providers/Microsoft.AzureStackHCI/galleryImages/ws2025-g2"
+          sofs_storage_path_ids:
+            "01": "/subscriptions/00000000/storageContainers/csv-01"
+            "02": "/subscriptions/00000000/storageContainers/csv-02"
+          sofs_vm_prefix: "TEST-SOFS"
+          sofs_vm_count: 2
+          sofs_vm_processors: 4
+          sofs_vm_memory_mb: 8192
+          sofs_admin_username: "TestAdmin"
+          sofs_data_disk_count: 2
+          sofs_data_disk_size_gb: 128
+          sofs_cloud_witness_name: "sttestwitness01"
+          sofs_guest_volume_layout: "option_a"
+          sofs_host_resiliency: "two_way"
+          sofs_guest_resiliency: "two_way"
+          sofs_cluster_name: "TEST-Cluster"
+          sofs_cluster_ip: "10.0.0.100"
+          sofs_access_point: "TestSOFS"
+          sofs_share_name: "TestShare"
+          sofs_s2d_volume_name: "TestData"
+          sofs_s2d_volume_size: "256GB"
+          sofs_s2d_data_copies: 2
+          sofs_s2d_pool_name: "S2D on TEST-Cluster"
+          sofs_smb_encryption: true
+          sofs_domain_fqdn: "test.local"
+          sofs_domain_netbios: "TEST"
+          sofs_domain_join_account: "svc.domainjoin"
+          sofs_domain_ou_nodes: "OU=Test,DC=test,DC=local"
+          sofs_anti_affinity_rule: "TEST-AntiAffinity"
+          sofs_azl_cluster_name: "TestCluster"
+          sofs_permissions_admin_group: "Domain Admins"
+          sofs_permissions_users_group: "Test-Users"
+          sofs_permissions_avd_users_group: "Test-Users"
+          sofs_fslogix_enabled: true
+          sofs_fslogix_profile_size_mb: 10000
+          sofs_fslogix_volume_type: "VHDX"
+          sofs_cloud_cache_enabled: false
+          sofs_dns_servers:
+            - "10.0.0.10"
+          ansible_connection: local
+        children:
+          sofs_nodes:
+            hosts:
+              sofs-test-01:
+                ansible_host: 127.0.0.1
+              sofs-test-02:
+                ansible_host: 127.0.0.2
+          host_cluster:
+            hosts:
+              host-test-01:
+                ansible_host: 127.0.0.10
+          avd_session_hosts:
+            hosts:
+              avd-test-01:
+                ansible_host: 127.0.0.20
+
+verifier:
+  name: ansible

--- a/src/ansible/playbooks/configure-fslogix.yml
+++ b/src/ansible/playbooks/configure-fslogix.yml
@@ -3,15 +3,20 @@
 # Applies FSLogix registry settings to AVD session hosts.
 #
 # Usage:
-#   ansible-playbook -i inventory/hosts.yml playbooks/configure-fslogix.yml
+#   ansible-playbook -i inventory/inventory.yml playbooks/configure-fslogix.yml
 
 - name: Configure FSLogix on AVD session hosts
   hosts: avd_session_hosts
   gather_facts: false
 
   vars:
-    fslogix_vhd_location: "\\\\SOFS01\\FSLogixProfiles"
+    access_point: "{{ sofs_access_point }}"
+    share_name: "{{ sofs_share_name | default('FSLogix') }}"
+    fslogix_vhd_location: "\\\\{{ access_point }}\\{{ share_name }}"
     fslogix_reg_path: "HKLM:\\SOFTWARE\\FSLogix\\Profiles"
+    fslogix_profile_size_mb: "{{ sofs_fslogix_profile_size_mb | default(30000) | int }}"
+    fslogix_volume_type: "{{ sofs_fslogix_volume_type | default('VHDX') }}"
+    cloud_cache_enabled: "{{ sofs_cloud_cache_enabled | default(false) | bool }}"
 
   tasks:
     - name: Ensure FSLogix Profiles registry key exists
@@ -32,6 +37,7 @@
         name: VHDLocations
         data: "{{ fslogix_vhd_location }}"
         type: string
+      when: not cloud_cache_enabled
 
     - name: Enable FlipFlopProfileDirectoryName (SID_Username format)
       ansible.windows.win_regedit:
@@ -47,18 +53,25 @@
         data: 1
         type: dword
 
-    - name: Set profile container size (MB) - default 30 GB
+    - name: Set profile container size (MB)
       ansible.windows.win_regedit:
         path: "{{ fslogix_reg_path }}"
         name: SizeInMBs
-        data: 30720
+        data: "{{ fslogix_profile_size_mb | int }}"
         type: dword
+
+    - name: Set volume type (VHD or VHDX)
+      ansible.windows.win_regedit:
+        path: "{{ fslogix_reg_path }}"
+        name: VolumeType
+        data: "{{ fslogix_volume_type }}"
+        type: string
 
     - name: Verify FSLogix configuration
       ansible.windows.win_powershell:
         script: |
           Get-ItemProperty -Path "{{ fslogix_reg_path }}" |
-            Select-Object Enabled, VHDLocations, FlipFlopProfileDirectoryName, SizeInMBs
+            Select-Object Enabled, VHDLocations, FlipFlopProfileDirectoryName, SizeInMBs, VolumeType
       register: fslogix_config
 
     - name: Show FSLogix configuration

--- a/src/ansible/playbooks/configure-sofs-cluster.yml
+++ b/src/ansible/playbooks/configure-sofs-cluster.yml
@@ -1,27 +1,62 @@
 # =============================================================================
 # SOFS on Azure Local — Configure Guest Cluster (Ansible Playbook)
 # =============================================================================
-# Configures the SOFS guest failover cluster on Windows Server VMs via WinRM:
-#   - Installs Failover Clustering + File Server roles
-#   - Creates the guest failover cluster
-#   - Configures cloud witness
-#   - Enables S2D, applies guest tuning
-#   - Creates the S2D volume
-#   - Adds SOFS role + FSLogix SMB share
-#   - Configures NTFS permissions
-#   - Validates the deployment
+# Phases covered:
+#   Phase 3 — Anti-affinity rule (host_cluster WinRM)
+#   Phase 5 — Install roles/features
+#   Phase 6 — Create failover cluster + cloud witness
+#   Phase 7 — Enable S2D, tuning, create volume(s)
+#   Phase 8 — Add SOFS role + create share(s)
+#   Phase 9 — NTFS permissions + SMB encryption
+#   Phase 9c — Cloud Cache (optional)
+#   Phase 11 — Validation
 #
-# Prerequisites:
-#   - SOFS VMs deployed and domain-joined (deploy-azure-resources.yml)
-#   - WinRM accessible from Ansible controller (Kerberos or NTLM)
-#   - pywinrm installed on Ansible controller
+# Supports Option A (single volume/share) and Option B (multiple)
+# via sofs_guest_volume_layout variable.
 #
 # Usage:
 #   ansible-playbook -i inventory.yml configure-sofs-cluster.yml
-#   ansible-playbook -i inventory.yml configure-sofs-cluster.yml --check  (dry-run)
+#   ansible-playbook -i inventory.yml configure-sofs-cluster.yml --check
 # =============================================================================
 ---
-- name: Configure SOFS Guest Cluster
+# =====================================================================
+# Phase 3: Anti-Affinity (runs on Azure Local HOST cluster via WinRM)
+# =====================================================================
+- name: "Phase 3 — Configure Anti-Affinity on Host Cluster"
+  hosts: host_cluster
+  gather_facts: false
+  run_once: true
+
+  vars:
+    anti_affinity_rule: "{{ sofs_anti_affinity_rule }}"
+    vm_prefix: "{{ sofs_vm_prefix }}"
+    vm_count: "{{ sofs_vm_count | int }}"
+
+  tasks:
+    - name: "Phase 3 — Create anti-affinity rule for SOFS VMs"
+      ansible.windows.win_powershell:
+        script: |
+          $ruleName = '{{ anti_affinity_rule }}'
+          $existing = Get-ClusterAffinityRule -Name $ruleName -ErrorAction SilentlyContinue
+          if (-not $existing) {
+              New-ClusterAffinityRule -Name $ruleName -RuleType AntiAffinity -ErrorAction Stop
+              Write-Output "Anti-affinity rule created: $ruleName"
+          } else {
+              Write-Output "Anti-affinity rule already exists: $ruleName"
+          }
+          {% for idx in range(1, vm_count | int + 1) %}
+          $vmName = '{{ vm_prefix }}-{{ '%02d' | format(idx) }}'
+          $vmResource = Get-ClusterGroup -Name $vmName -ErrorAction SilentlyContinue
+          if ($vmResource) {
+              Add-ClusterGroupToAffinityRule -Groups $vmResource -Name $ruleName -ErrorAction SilentlyContinue
+              Write-Output "Added $vmName to $ruleName"
+          }
+          {% endfor %}
+
+# =====================================================================
+# Phases 5-11: Guest OS Configuration (runs on SOFS VMs via WinRM)
+# =====================================================================
+- name: "Configure SOFS Guest Cluster (Phases 5-11)"
   hosts: sofs_nodes
   gather_facts: true
 
@@ -29,17 +64,33 @@
     cluster_name: "{{ sofs_cluster_name }}"
     cluster_ip: "{{ sofs_cluster_ip }}"
     access_point: "{{ sofs_access_point }}"
-    share_name: "{{ sofs_share_name }}"
+    share_name: "{{ sofs_share_name | default('FSLogix') }}"
     witness_account: "{{ sofs_cloud_witness_name }}"
-    witness_key: "{{ sofs_witness_key }}"               # pass via --extra-vars or vault
+    witness_key: "{{ sofs_witness_key }}"
     witness_endpoint: "core.windows.net"
-    s2d_volume_name: "{{ sofs_s2d_volume_name }}"
-    s2d_volume_size: "{{ sofs_s2d_volume_size }}"
-    s2d_data_copies: "{{ sofs_s2d_data_copies | int }}"
+    s2d_volume_name: "{{ sofs_s2d_volume_name | default('FSLogixData') }}"
+    s2d_volume_size: "{{ sofs_s2d_volume_size | default('5632GB') }}"
+    s2d_data_copies: "{{ sofs_s2d_data_copies | default(2) | int }}"
+    s2d_pool_name: "{{ sofs_s2d_pool_name | default('S2D on ' ~ sofs_cluster_name) }}"
+    sofs_role_name: "{{ sofs_sofs_role_name | default(sofs_access_point) }}"
+    smb_encryption: "{{ sofs_smb_encryption | default(true) }}"
     domain_netbios: "{{ sofs_domain_netbios }}"
+    guest_volume_layout: "{{ sofs_guest_volume_layout | default('option_a') }}"
     anti_affinity_rule: "{{ sofs_anti_affinity_rule }}"
     azl_cluster_name: "{{ sofs_azl_cluster_name }}"
     vm_names: "{{ groups['sofs_nodes'] }}"
+    # Permissions
+    admin_group: "{{ sofs_permissions_admin_group | default('Domain Admins') }}"
+    users_group: "{{ sofs_permissions_users_group | default('AVD-Users') }}"
+    avd_users_group: "{{ sofs_permissions_avd_users_group | default('AVD-Users') }}"
+    # Option B lists (empty defaults for Option A)
+    sofs_shares_list: "{{ sofs_shares | default([]) }}"
+    s2d_volumes_list: "{{ sofs_s2d_volumes | default([]) }}"
+    # FSLogix
+    fslogix_enabled: "{{ sofs_fslogix_enabled | default(true) }}"
+    fslogix_profile_size_mb: "{{ sofs_fslogix_profile_size_mb | default(30000) }}"
+    # DNS
+    dns_servers: "{{ sofs_dns_servers | default([]) }}"
 
   tasks:
     # -----------------------------------------------------------------
@@ -62,7 +113,7 @@
       when: feature_install.reboot_required
 
     # -----------------------------------------------------------------
-    # Phase 6: Create Guest Failover Cluster (run on first node only)
+    # Phase 6: Create Guest Failover Cluster (first node only)
     # -----------------------------------------------------------------
     - name: "Phase 6 — Validate cluster"
       ansible.windows.win_powershell:
@@ -135,26 +186,54 @@
           Write-Output "AutoReplace disabled"
       when: inventory_hostname == groups['sofs_nodes'][0]
 
-    - name: "Phase 7 — Create S2D volume"
+    # --- Option A: Single volume ---
+    - name: "Phase 7 — Create S2D volume (Option A)"
       ansible.windows.win_powershell:
         script: |
           $existing = Get-VirtualDisk -FriendlyName {{ s2d_volume_name }} -ErrorAction SilentlyContinue
           if (-not $existing) {
               New-Volume -FriendlyName {{ s2d_volume_name }} `
-                         -StoragePoolFriendlyName "S2D on {{ cluster_name }}" `
+                         -StoragePoolFriendlyName "{{ s2d_pool_name }}" `
                          -FileSystem CSVFS_ReFS `
                          -ResiliencySettingName Mirror `
                          -NumberOfDataCopies {{ s2d_data_copies }} `
                          -Size {{ s2d_volume_size }} `
                          -ErrorAction Stop | Out-Null
-              Write-Output "Volume created"
+              Write-Output "Volume {{ s2d_volume_name }} created"
           } else {
-              Write-Output "Volume already exists"
+              Write-Output "Volume {{ s2d_volume_name }} already exists"
           }
-      when: inventory_hostname == groups['sofs_nodes'][0]
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - guest_volume_layout == 'option_a'
+
+    # --- Option B: Multiple volumes ---
+    - name: "Phase 7 — Create S2D volumes (Option B)"
+      ansible.windows.win_powershell:
+        script: |
+          $existing = Get-VirtualDisk -FriendlyName '{{ item.name }}' -ErrorAction SilentlyContinue
+          if (-not $existing) {
+              New-Volume -FriendlyName '{{ item.name }}' `
+                         -StoragePoolFriendlyName "{{ s2d_pool_name }}" `
+                         -FileSystem CSVFS_ReFS `
+                         -ResiliencySettingName Mirror `
+                         -NumberOfDataCopies {{ item.data_copies }} `
+                         -Size {{ item.size_gb }}GB `
+                         -ErrorAction Stop | Out-Null
+              Write-Output "Volume {{ item.name }} created"
+          } else {
+              Write-Output "Volume {{ item.name }} already exists"
+          }
+      loop: "{{ s2d_volumes_list }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - guest_volume_layout == 'option_b'
+        - s2d_volumes_list | length > 0
 
     # -----------------------------------------------------------------
-    # Phase 8: Add SOFS Role and Create FSLogix Share
+    # Phase 8: Add SOFS Role and Create Shares
     # -----------------------------------------------------------------
     - name: "Phase 8 — Add SOFS cluster role"
       ansible.windows.win_powershell:
@@ -170,7 +249,8 @@
           }
       when: inventory_hostname == groups['sofs_nodes'][0]
 
-    - name: "Phase 8 — Create FSLogix SMB share"
+    # --- Option A: Single share ---
+    - name: "Phase 8 — Create FSLogix SMB share (Option A)"
       ansible.windows.win_powershell:
         script: |
           $CSV = Get-ClusterSharedVolume -Cluster {{ cluster_name }} |
@@ -187,20 +267,59 @@
                            -ScopeName {{ access_point }} `
                            -ContinuouslyAvailable $true `
                            -CachingMode None `
-                           -FullAccess "{{ domain_netbios }}\Domain Admins" `
-                           -ChangeAccess "{{ domain_netbios }}\Domain Users" `
+                           -FullAccess "{{ domain_netbios }}\{{ admin_group }}" `
+                           -ChangeAccess "{{ domain_netbios }}\{{ users_group }}" `
                            -FolderEnumerationMode AccessBased `
+                           -EncryptData ${{ smb_encryption | string | lower }} `
                            -ErrorAction Stop | Out-Null
               Write-Output "Share created: \\{{ access_point }}\{{ share_name }}"
           } else {
               Write-Output "Share already exists"
           }
-      when: inventory_hostname == groups['sofs_nodes'][0]
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - guest_volume_layout == 'option_a'
+
+    # --- Option B: Multiple shares ---
+    - name: "Phase 8 — Create SMB shares (Option B)"
+      ansible.windows.win_powershell:
+        script: |
+          $CSV = Get-ClusterSharedVolume -Cluster {{ cluster_name }} |
+              Where-Object { $_.SharedVolumeInfo.FriendlyVolumeName -match '{{ item.volume }}' }
+          $CSVPath = $CSV.SharedVolumeInfo.FriendlyVolumeName
+          $SharePath = Join-Path $CSVPath "{{ item.name }}"
+
+          New-Item -Path $SharePath -ItemType Directory -Force | Out-Null
+
+          $existing = Get-SmbShare -Name '{{ item.name }}' -ScopeName {{ access_point }} -ErrorAction SilentlyContinue
+          if (-not $existing) {
+              New-SmbShare -Name '{{ item.name }}' `
+                           -Path $SharePath `
+                           -ScopeName {{ access_point }} `
+                           -ContinuouslyAvailable $true `
+                           -CachingMode None `
+                           -FullAccess "{{ domain_netbios }}\{{ admin_group }}" `
+                           -ChangeAccess "{{ domain_netbios }}\{{ users_group }}" `
+                           -FolderEnumerationMode AccessBased `
+                           -EncryptData ${{ smb_encryption | string | lower }} `
+                           -ErrorAction Stop | Out-Null
+              Write-Output "Share created: \\{{ access_point }}\{{ item.name }}"
+          } else {
+              Write-Output "Share {{ item.name }} already exists"
+          }
+      loop: "{{ sofs_shares_list }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - guest_volume_layout == 'option_b'
+        - sofs_shares_list | length > 0
 
     # -----------------------------------------------------------------
     # Phase 9: NTFS Permissions
     # -----------------------------------------------------------------
-    - name: "Phase 9 — Configure NTFS permissions for FSLogix"
+    # --- Option A ---
+    - name: "Phase 9 — Configure NTFS permissions (Option A)"
       ansible.windows.win_powershell:
         script: |
           $CSV = Get-ClusterSharedVolume -Cluster {{ cluster_name }} |
@@ -211,19 +330,12 @@
           $acl = Get-Acl $SharePath
           $acl.SetAccessRuleProtection($true, $false)
 
-          # CREATOR OWNER — Modify (subfolders and files only)
           $rule1 = New-Object System.Security.AccessControl.FileSystemAccessRule(
               "CREATOR OWNER", "Modify", "ContainerInherit,ObjectInherit", "InheritOnly", "Allow")
-
-          # Domain Users — Modify (this folder only)
           $rule2 = New-Object System.Security.AccessControl.FileSystemAccessRule(
-              "{{ domain_netbios }}\Domain Users", "Modify", "None", "None", "Allow")
-
-          # Domain Admins — Full Control
+              "{{ domain_netbios }}\{{ avd_users_group }}", "Modify", "None", "None", "Allow")
           $rule3 = New-Object System.Security.AccessControl.FileSystemAccessRule(
-              "{{ domain_netbios }}\Domain Admins", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
-
-          # SYSTEM — Full Control
+              "{{ domain_netbios }}\{{ admin_group }}", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
           $rule4 = New-Object System.Security.AccessControl.FileSystemAccessRule(
               "NT AUTHORITY\SYSTEM", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
 
@@ -232,8 +344,70 @@
           $acl.AddAccessRule($rule3)
           $acl.AddAccessRule($rule4)
           Set-Acl -Path $SharePath -AclObject $acl
-          Write-Output "NTFS permissions configured"
-      when: inventory_hostname == groups['sofs_nodes'][0]
+          Write-Output "NTFS permissions configured for {{ share_name }}"
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - guest_volume_layout == 'option_a'
+
+    # --- Option B ---
+    - name: "Phase 9 — Configure NTFS permissions (Option B)"
+      ansible.windows.win_powershell:
+        script: |
+          $CSV = Get-ClusterSharedVolume -Cluster {{ cluster_name }} |
+              Where-Object { $_.SharedVolumeInfo.FriendlyVolumeName -match '{{ item.volume }}' }
+          $CSVPath = $CSV.SharedVolumeInfo.FriendlyVolumeName
+          $SharePath = Join-Path $CSVPath "{{ item.name }}"
+
+          $acl = Get-Acl $SharePath
+          $acl.SetAccessRuleProtection($true, $false)
+
+          $rule1 = New-Object System.Security.AccessControl.FileSystemAccessRule(
+              "CREATOR OWNER", "Modify", "ContainerInherit,ObjectInherit", "InheritOnly", "Allow")
+          $rule2 = New-Object System.Security.AccessControl.FileSystemAccessRule(
+              "{{ domain_netbios }}\{{ avd_users_group }}", "Modify", "None", "None", "Allow")
+          $rule3 = New-Object System.Security.AccessControl.FileSystemAccessRule(
+              "{{ domain_netbios }}\{{ admin_group }}", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
+          $rule4 = New-Object System.Security.AccessControl.FileSystemAccessRule(
+              "NT AUTHORITY\SYSTEM", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
+
+          $acl.AddAccessRule($rule1)
+          $acl.AddAccessRule($rule2)
+          $acl.AddAccessRule($rule3)
+          $acl.AddAccessRule($rule4)
+          Set-Acl -Path $SharePath -AclObject $acl
+          Write-Output "NTFS permissions configured for {{ item.name }}"
+      loop: "{{ sofs_shares_list }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - guest_volume_layout == 'option_b'
+        - sofs_shares_list | length > 0
+
+    # --- SMB Encryption ---
+    - name: "Phase 9 — Enable SMB server-wide encryption"
+      ansible.windows.win_powershell:
+        script: |
+          Set-SmbServerConfiguration -EncryptData ${{ smb_encryption | string | lower }} -Confirm:$false
+          Write-Output "SMB encryption set to {{ smb_encryption }}"
+      when: smb_encryption | bool
+
+    # -----------------------------------------------------------------
+    # Phase 9c: Cloud Cache (optional)
+    # -----------------------------------------------------------------
+    - name: "Phase 9c — Configure Cloud Cache provider"
+      ansible.windows.win_powershell:
+        script: |
+          # Cloud Cache configuration is applied via FSLogix GPO / registry
+          # This task creates the CCDLocations registry value
+          $regPath = 'HKLM:\SOFTWARE\FSLogix\Profiles'
+          if (-not (Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }
+          Set-ItemProperty -Path $regPath -Name 'CCDLocations' `
+              -Value '{{ sofs_cloud_cache_azure_provider | default("") }}' -Type String
+          Write-Output "Cloud Cache CCDLocations configured"
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - sofs_cloud_cache_enabled | default(false) | bool
 
     # -----------------------------------------------------------------
     # Phase 11: Validation
@@ -250,18 +424,18 @@
         msg: "{{ cluster_nodes.output | default('N/A') }}"
       when: inventory_hostname == groups['sofs_nodes'][0]
 
-    - name: "Phase 11 — Verify SOFS share"
+    - name: "Phase 11 — Verify SOFS shares"
       ansible.windows.win_powershell:
         script: |
-          Get-SmbShare -Name {{ share_name }} -ScopeName {{ access_point }} |
-              Select-Object Name, ScopeName, ContinuouslyAvailable, CachingMode, Path |
+          Get-SmbShare -ScopeName {{ access_point }} -ErrorAction SilentlyContinue |
+              Select-Object Name, ScopeName, ContinuouslyAvailable, EncryptData, Path |
               ConvertTo-Json
       when: inventory_hostname == groups['sofs_nodes'][0]
-      register: sofs_share
+      register: sofs_shares_result
 
-    - name: Display SOFS share
+    - name: Display SOFS shares
       ansible.builtin.debug:
-        msg: "{{ sofs_share.output | default('N/A') }}"
+        msg: "{{ sofs_shares_result.output | default('N/A') }}"
       when: inventory_hostname == groups['sofs_nodes'][0]
 
     - name: Deployment summary
@@ -271,12 +445,17 @@
           SOFS Guest Cluster Configuration Complete
           ============================================
           Cluster:        {{ cluster_name }} ({{ cluster_ip }})
+          Layout:         {{ guest_volume_layout }}
           SOFS Name:      {{ access_point }}
+          {% if guest_volume_layout == 'option_a' %}
           Share:          \\{{ access_point }}\{{ share_name }}
           S2D Volume:     {{ s2d_volume_name }} ({{ s2d_volume_size }}, {{ s2d_data_copies }}-way mirror)
+          {% else %}
+          Shares:         {{ sofs_shares_list | map(attribute='name') | join(', ') }}
+          Volumes:        {{ s2d_volumes_list | map(attribute='name') | join(', ') }}
+          {% endif %}
           Cloud Witness:  {{ witness_account }}
           Domain:         {{ domain_netbios }}
-          ============================================
-          NEXT: Set FSLogix VHDLocations to \\{{ access_point }}\{{ share_name }}
+          SMB Encryption: {{ smb_encryption }}
           ============================================
       when: inventory_hostname == groups['sofs_nodes'][0]

--- a/src/ansible/playbooks/configure-sofs.yml
+++ b/src/ansible/playbooks/configure-sofs.yml
@@ -3,49 +3,42 @@
 # Configures SMB share settings and optimisations on SOFS cluster nodes.
 #
 # Usage:
-#   ansible-playbook -i inventory/hosts.yml playbooks/configure-sofs.yml
+#   ansible-playbook -i inventory/inventory.yml playbooks/configure-sofs.yml
 
 - name: Configure SOFS SMB share for FSLogix
   hosts: sofs_nodes
   gather_facts: false
 
   vars:
-    sofs_name: "SOFS01"
-    share_name: "FSLogixProfiles"
-    share_path: "C:\\ClusterStorage\\Volume1\\FSLogixProfiles"
-    avd_users_group: "AVD-Users"
+    access_point: "{{ sofs_access_point }}"
+    share_name: "{{ sofs_share_name | default('FSLogix') }}"
+    smb_encryption: "{{ sofs_smb_encryption | default(true) }}"
 
   tasks:
-    - name: Ensure FSLogixProfiles directory exists on CSV
-      ansible.windows.win_file:
-        path: "{{ share_path }}"
-        state: directory
-
-    - name: Create SMB share (if not present)
-      community.windows.win_share:
-        name: "{{ share_name }}"
-        path: "{{ share_path }}"
-        state: present
-        full: "{{ avd_users_group }},CREATOR OWNER"
-        description: "FSLogix profile containers"
-
     - name: Enable SMB encryption on the server
       ansible.windows.win_powershell:
         script: |
-          Set-SmbServerConfiguration -EncryptData $true -Confirm:$false
+          Set-SmbServerConfiguration -EncryptData ${{ smb_encryption | string | lower }} -Confirm:$false
+      when: smb_encryption | bool
 
     - name: Enable access-based enumeration on the share
       ansible.windows.win_powershell:
         script: |
-          Set-SmbShare -Name "{{ share_name }}" -FolderEnumerationMode AccessBased -ContinuouslyAvailable $true -Confirm:$false
+          Set-SmbShare -Name "{{ share_name }}" -ScopeName "{{ access_point }}" `
+                       -FolderEnumerationMode AccessBased `
+                       -ContinuouslyAvailable $true -Confirm:$false
         error_action: stop
+      when: inventory_hostname == groups['sofs_nodes'][0]
 
     - name: Report share configuration
       ansible.windows.win_powershell:
         script: |
-          Get-SmbShare -Name "{{ share_name }}" | Select-Object Name, Path, EncryptData, ContinuouslyAvailable
+          Get-SmbShare -ScopeName "{{ access_point }}" |
+              Select-Object Name, Path, EncryptData, ContinuouslyAvailable
       register: share_info
+      when: inventory_hostname == groups['sofs_nodes'][0]
 
     - name: Show share configuration
       ansible.builtin.debug:
         var: share_info.output
+      when: inventory_hostname == groups['sofs_nodes'][0]

--- a/src/ansible/playbooks/deploy-azure-resources.yml
+++ b/src/ansible/playbooks/deploy-azure-resources.yml
@@ -4,12 +4,13 @@
 # Creates all Azure-side resources using Azure CLI via command/shell modules.
 # Run from a management workstation with Azure CLI authenticated.
 #
+# Phases covered:
+#   Phase 1 — Azure resources (RG, witness, NICs, VMs, disks)
+#   Phase 2 — Domain join via Arc connected-machine extension
+#
 # Usage:
 #   ansible-playbook -i inventory.yml deploy-azure-resources.yml
 #   ansible-playbook -i inventory.yml deploy-azure-resources.yml --check  (dry-run)
-#
-# NOTE: This playbook runs against localhost — it provisions Azure resources,
-#       not guest OS configuration. Use configure-sofs-cluster.yml for that.
 # =============================================================================
 ---
 - name: Deploy SOFS Azure Resources
@@ -18,14 +19,13 @@
   gather_facts: false
 
   vars:
-    # Pull vars from inventory (all.vars) or override via --extra-vars
     subscription_id: "{{ sofs_subscription_id }}"
     resource_group: "{{ sofs_resource_group }}"
     location: "{{ sofs_location }}"
     custom_location_id: "{{ sofs_custom_location_id }}"
     logical_network_id: "{{ sofs_logical_network_id }}"
-    gallery_image: "{{ sofs_gallery_image }}"
-    storage_path_id: "{{ sofs_storage_path_id }}"
+    gallery_image_id: "{{ sofs_gallery_image_id }}"
+    storage_path_ids: "{{ sofs_storage_path_ids }}"
     vm_prefix: "{{ sofs_vm_prefix }}"
     vm_count: "{{ sofs_vm_count | int }}"
     vm_processors: "{{ sofs_vm_processors | int }}"
@@ -35,7 +35,12 @@
     data_disk_count: "{{ sofs_data_disk_count | int }}"
     data_disk_size_gb: "{{ sofs_data_disk_size_gb | int }}"
     cloud_witness_name: "{{ sofs_cloud_witness_name }}"
-    tags: "project=SOFS environment=production workload=FSLogix solution=sofs-azure-local"
+    domain_fqdn: "{{ sofs_domain_fqdn }}"
+    domain_netbios: "{{ sofs_domain_netbios }}"
+    domain_join_account: "{{ sofs_domain_join_account }}"
+    domain_join_password: "{{ sofs_domain_join_password }}"
+    domain_ou_nodes: "{{ sofs_domain_ou_nodes | default('') }}"
+    tags: "{{ sofs_tags | default('project=SOFS workload=FSLogix solution=sofs-azure-local') }}"
 
   tasks:
     # -----------------------------------------------------------------
@@ -50,9 +55,22 @@
       changed_when: false
 
     # -----------------------------------------------------------------
-    # Step 1: Cloud Witness Storage Account
+    # Phase 1a: Resource Group
     # -----------------------------------------------------------------
-    - name: Create cloud witness storage account
+    - name: "Phase 1a — Create resource group"
+      ansible.builtin.command: >
+        az group create
+          --name {{ resource_group }}
+          --location {{ location }}
+          --tags {{ tags }}
+          --output none
+      register: rg_result
+      changed_when: rg_result.rc == 0
+
+    # -----------------------------------------------------------------
+    # Phase 1b: Cloud Witness Storage Account
+    # -----------------------------------------------------------------
+    - name: "Phase 1b — Create cloud witness storage account"
       ansible.builtin.command: >
         az storage account create
           --name {{ cloud_witness_name }}
@@ -60,6 +78,8 @@
           --location {{ location }}
           --sku Standard_LRS
           --kind StorageV2
+          --min-tls-version TLS1_2
+          --allow-blob-public-access false
           --tags {{ tags }}
           --output none
       register: witness_result
@@ -81,9 +101,9 @@
       no_log: true
 
     # -----------------------------------------------------------------
-    # Step 2: Create NICs
+    # Phase 1c: Create NICs
     # -----------------------------------------------------------------
-    - name: Create NICs on compute logical network
+    - name: "Phase 1c — Create NICs on compute logical network"
       ansible.builtin.command: >
         az stack-hci-vm network nic create
           --resource-group {{ resource_group }}
@@ -98,22 +118,22 @@
         label: "{{ vm_prefix }}-{{ '%02d' | format(item) }}-nic"
 
     # -----------------------------------------------------------------
-    # Step 3: Create VMs
+    # Phase 1d: Create VMs (with per-VM storage path mapping)
     # -----------------------------------------------------------------
-    - name: Create SOFS VMs
+    - name: "Phase 1d — Create SOFS VMs"
       ansible.builtin.command: >
         az stack-hci-vm create
           --name {{ vm_prefix }}-{{ '%02d' | format(item) }}
           --resource-group {{ resource_group }}
           --custom-location {{ custom_location_id }}
           --location {{ location }}
-          --image {{ gallery_image }}
+          --image {{ gallery_image_id }}
           --admin-username {{ admin_username }}
           --admin-password {{ admin_password }}
           --computer-name {{ vm_prefix }}-{{ '%02d' | format(item) }}
           --hardware-profile memory-mb="{{ vm_memory_mb }}" processors="{{ vm_processors }}"
           --nics {{ vm_prefix }}-{{ '%02d' | format(item) }}-nic
-          --storage-path-id {{ storage_path_id }}
+          --storage-path-id {{ storage_path_ids['%02d' | format(item)] | default(storage_path_ids.values() | first) }}
           --authentication-type all
           --enable-agent true
           --tags {{ tags }}
@@ -121,19 +141,17 @@
       loop: "{{ range(1, vm_count | int + 1) | list }}"
       loop_control:
         label: "{{ vm_prefix }}-{{ '%02d' | format(item) }}"
-      no_log: true  # hide admin_password from output
+      no_log: true
 
     # -----------------------------------------------------------------
-    # Step 4: Create Data Disks
+    # Phase 1e: Create & Attach Data Disks
     # -----------------------------------------------------------------
     - name: Build data disk list
       ansible.builtin.set_fact:
         data_disk_list: >-
-          {{
-            range(1, vm_count | int + 1) | product(range(1, data_disk_count | int + 1)) | list
-          }}
+          {{ range(1, vm_count | int + 1) | product(range(1, data_disk_count | int + 1)) | list }}
 
-    - name: Create data disks for S2D pool
+    - name: "Phase 1e — Create data disks for S2D pool"
       ansible.builtin.command: >
         az stack-hci-vm disk create
           --resource-group {{ resource_group }}
@@ -142,28 +160,14 @@
           --name {{ vm_prefix }}-{{ '%02d' | format(item[0]) }}-data{{ item[1] }}
           --size-gb {{ data_disk_size_gb }}
           --dynamic true
-          --storage-path-id {{ storage_path_id }}
+          --storage-path-id {{ storage_path_ids['%02d' | format(item[0])] | default(storage_path_ids.values() | first) }}
           --tags {{ tags }}
           --output none
       loop: "{{ data_disk_list }}"
       loop_control:
         label: "{{ vm_prefix }}-{{ '%02d' | format(item[0]) }}-data{{ item[1] }}"
 
-    # -----------------------------------------------------------------
-    # Step 5: Attach Data Disks to VMs
-    # -----------------------------------------------------------------
-    - name: Build disk name lists per VM
-      ansible.builtin.set_fact:
-        vm_disk_names: >-
-          {{
-            dict(
-              range(1, vm_count | int + 1) | map('regex_replace', '^(.*)$', vm_prefix ~ '-' ~ '\1') |
-              zip(range(1, vm_count | int + 1) | map('apply_format') | list) | list
-            )
-          }}
-      ignore_errors: true  # complex Jinja — fallback below
-
-    - name: Attach data disks to VMs
+    - name: "Phase 1e — Attach data disks to VMs"
       ansible.builtin.command: >
         az stack-hci-vm disk attach
           --resource-group {{ resource_group }}
@@ -176,7 +180,33 @@
         label: "{{ vm_prefix }}-{{ '%02d' | format(item) }}"
 
     # -----------------------------------------------------------------
-    # Step 6: Verify
+    # Phase 2: Domain Join via Arc Extension
+    # -----------------------------------------------------------------
+    - name: "Phase 2 — Domain join SOFS VMs via JsonADDomainExtension"
+      ansible.builtin.command: >
+        az connectedmachine extension create
+          --resource-group {{ resource_group }}
+          --machine-name {{ vm_prefix }}-{{ '%02d' | format(item) }}
+          --name JsonADDomainExtension
+          --location {{ location }}
+          --type JsonADDomainExtension
+          --publisher Microsoft.Compute
+          --settings '{
+            "Name": "{{ domain_fqdn }}",
+            "User": "{{ domain_netbios }}\\{{ domain_join_account }}",
+            "OUPath": "{{ domain_ou_nodes }}",
+            "Restart": "true",
+            "Options": "3"
+          }'
+          --protected-settings '{"Password": "{{ domain_join_password }}"}'
+          --output none
+      loop: "{{ range(1, vm_count | int + 1) | list }}"
+      loop_control:
+        label: "{{ vm_prefix }}-{{ '%02d' | format(item) }}"
+      no_log: true
+
+    # -----------------------------------------------------------------
+    # Verify
     # -----------------------------------------------------------------
     - name: List deployed VMs
       ansible.builtin.command: az stack-hci-vm list --resource-group {{ resource_group }} -o table
@@ -197,6 +227,7 @@
           Data Disks per VM:  {{ data_disk_count }} x {{ data_disk_size_gb }} GB
           Total S2D Pool:     {{ (vm_count | int * data_disk_count | int * data_disk_size_gb | int / 1024) | int }} TB
           Cloud Witness:      {{ cloud_witness_name }}
+          Domain Joined:      {{ domain_fqdn }}
           ============================================
           NEXT: Run configure-sofs-cluster.yml
           ============================================

--- a/src/ansible/requirements.yml
+++ b/src/ansible/requirements.yml
@@ -1,0 +1,14 @@
+---
+# =============================================================================
+# SOFS on Azure Local — Ansible Collection Requirements
+# =============================================================================
+# Install with: ansible-galaxy collection install -r requirements.yml
+# =============================================================================
+
+collections:
+  - name: ansible.windows
+    version: ">=2.3.0"
+  - name: community.windows
+    version: ">=2.2.0"
+  - name: azure.azcollection
+    version: ">=2.4.0"


### PR DESCRIPTION
## Summary\n\nCloses #63 — Ansible End-to-End + Verified Collections\n\n### Changes\n\n**New files:**\n- `requirements.yml` — Pinned collection versions (ansible.windows >=2.3, community.windows >=2.2, azure.azcollection >=2.4)\n- `.ansible-lint` — Production profile with appropriate skip rules for az CLI tasks\n- `molecule/default/molecule.yml` — Delegated driver test scenario with full variable set\n- `molecule/default/converge.yml` — Syntax validation converge playbook\n\n**Updated playbooks:**\n- `deploy-azure-resources.yml` — Added Phase 1a (resource group), Phase 2 (domain join via Arc JsonADDomainExtension), per-VM storage path mapping, TLS 1.2 on witness, all new variable references\n- `configure-sofs-cluster.yml` — Split into two plays (Phase 3 anti-affinity on host_cluster + Phases 5-11 on sofs_nodes), Option A/B branching for volumes/shares, per-volume/per-share loops, Cloud Cache Phase 9c, configurable permissions groups, SMB encryption toggle\n- `configure-fslogix.yml` — Uses inventory variables for VHD location, profile size, volume type; conditional VHDLocations when Cloud Cache disabled\n- `configure-sofs.yml` — Uses inventory variables, scoped share queries\n\n**Updated inventory:**\n- `inventory.yml` — 30+ new variables (permissions, FSLogix, DNS, resiliency, Option A/B, storage path IDs), host_cluster group for anti-affinity, avd_session_hosts group\n- `hosts.example.yml` — Added host_cluster group\n\n### Acceptance Criteria\n- [x] `requirements.yml` with pinned collection versions\n- [x] Phase 3 (anti-affinity) on host_cluster\n- [x] Phase 4 (domain join) via Arc extension\n- [x] Option A/B branching in configure playbook\n- [x] All values parameterized from inventory\n- [x] host_cluster group added\n- [x] molecule test scenarios\n- [x] .ansible-lint config\n- [x] Support 2-16 nodes\n- [x] Per-volume/per-share loops for Option B"