### PR TITLE
feat(#66): Cloud Cache DR — multi-provider CCDLocations across all 5 tools

### DIFF
--- a/config/schema/variables.schema.json
+++ b/config/schema/variables.schema.json
@@ -208,7 +208,19 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
-            "azure_provider": { "type": "string" }
+            "azure_provider": { "type": "string", "description": "Deprecated — use providers array" },
+            "providers": {
+              "type": "array",
+              "description": "Ordered list of additional Cloud Cache providers (e.g. Azure Blob DR). SMB providers are auto-generated from SOFS shares.",
+              "items": {
+                "type": "object",
+                "required": ["type", "connectionString"],
+                "properties": {
+                  "type": { "type": "string", "enum": ["smb", "azure", "smb2"] },
+                  "connectionString": { "type": "string" }
+                }
+              }
+            }
           }
         }
       }

--- a/config/variables.example.yml
+++ b/config/variables.example.yml
@@ -240,7 +240,16 @@ fslogix:
   delete_local_profile: true
   cloud_cache:
     enabled: false
-    azure_provider: ""                     # Azure Blob connection string (if Cloud Cache enabled)
+    azure_provider: ""                     # (DEPRECATED — use providers array instead)
+    # providers — ordered list of Cloud Cache providers for CCDLocations.
+    # Each entry needs type (smb, azure, smb2) and connectionString.
+    # SMB providers for the SOFS shares are auto-generated; list only
+    # additional providers here (e.g. Azure Blob for DR).
+    providers: []
+    # Example multi-provider setup:
+    # providers:
+    #   - type: "azure"
+    #     connectionString: "DefaultEndpointsProtocol=https;AccountName=stfslogixdr;..."
 
 
 # =============================================================================

--- a/docs/architecture/cloud-cache.md
+++ b/docs/architecture/cloud-cache.md
@@ -1,0 +1,109 @@
+# Cloud Cache DR Architecture
+
+## Overview
+
+FSLogix Cloud Cache provides a **disaster recovery (DR) overlay** for profile containers hosted on SOFS. Instead of writing profiles to a single SMB share (VHDLocations), Cloud Cache writes simultaneously to multiple providers via the **CCDLocations** registry value, giving:
+
+- **Multi-site redundancy** — profiles are replicated to Azure Blob Storage (or a second SMB share) in near-real-time.
+- **Reduced SOFS read load** — the local cache on each AVD session host absorbs read I/O.
+- **Transparent failover** — if the SOFS share is unavailable, the Cloud Cache driver fails over to the next healthy provider.
+
+## When to Use Cloud Cache
+
+| Scenario | Recommended? |
+|---|---|
+| Single-site SOFS with no DR requirement | No — standard VHDLocations is simpler |
+| SOFS with Azure Blob DR target | **Yes** — primary use case |
+| Multi-site SOFS (active/active) | Yes — list both SMB endpoints |
+| Compliance requiring off-site backup | Yes — Azure Blob provider as secondary |
+
+## Architecture
+
+```
+AVD Session Host
+  └─ FSLogix Cloud Cache Driver (frxccd.sys)
+       ├─ Provider 1: type=smb  → \\FSLogixSOFS\Profiles  (SOFS primary)
+       └─ Provider 2: type=azure → Azure Blob Storage      (DR target)
+```
+
+The Cloud Cache driver maintains a **local cache** (`%TEMP%\intlMountPoints`) and writes to every provider in the CCDLocations list. Reads are served from the local cache. If a provider is unreachable, writes queue locally and resync when connectivity returns.
+
+## Configuration
+
+### Enable Cloud Cache
+
+In `config/variables.yml`:
+
+```yaml
+fslogix:
+  cloud_cache:
+    enabled: true
+    providers:
+      - type: "azure"
+        connectionString: "DefaultEndpointsProtocol=https;AccountName=stfslogixdr;AccountKey=..."
+```
+
+### Provider Types
+
+| Type | Description | Connection String Format |
+|---|---|---|
+| `smb` | SMB file share (auto-generated from SOFS shares) | `\\server\share` |
+| `azure` | Azure Blob Storage account | Standard Azure Storage connection string |
+| `smb2` | Secondary SMB share (manual) | `\\server2\share` |
+
+> **Note:** SMB providers for the SOFS shares are automatically generated. Only list additional providers (Azure Blob, secondary SMB) in the `providers` array.
+
+### CCDLocations Registry Value
+
+The tools generate the `CCDLocations` value automatically when Cloud Cache is enabled:
+
+```
+type=smb,connectionString=\\FSLogixSOFS\Profiles;type=azure,connectionString=DefaultEndpointsProtocol=https;AccountName=stfslogixdr;...
+```
+
+- **Registry key:** `HKLM:\SOFTWARE\FSLogix\Profiles`
+- **Value name:** `CCDLocations`
+- **Value type:** `REG_EXPAND_SZ`
+- **Applied to:** AVD session hosts (not SOFS VMs)
+
+When Cloud Cache is enabled, the `VHDLocations` registry value is removed — the two are mutually exclusive.
+
+## Tool Support
+
+All five deployment tools support Cloud Cache:
+
+| Tool | Config Source | CCDLocations Generation |
+|---|---|---|
+| **PowerShell** | `config/variables.yml` → `fslogix.cloud_cache` | Phase 9c in Configure-SOFS-Cluster.ps1 |
+| **Ansible** | Inventory vars `sofs_cloud_cache_*` | Phase 9c in configure-sofs-cluster.yml + configure-fslogix.yml |
+| **Terraform** | `cloud_cache_providers` variable | Passed to Ansible inventory template |
+| **Bicep** | `cloudCacheProviders` parameter | Passed to guest config engine |
+| **ARM** | `cloudCacheProviders` parameter | Compiled from Bicep |
+
+### Provider Resolution Order
+
+1. `providers[]` array (preferred)
+2. `azure_provider` string (legacy fallback, deprecated)
+
+## Prerequisites
+
+1. **Azure Storage Account** — create a Standard StorageV2 account for the DR target.
+2. **Network connectivity** — AVD session hosts must reach both the SOFS share and the Azure Storage endpoint.
+3. **FSLogix agent** — version 2210+ recommended for Cloud Cache stability improvements.
+4. **Local cache disk space** — each AVD session host needs temporary disk space for the local cache (`%TEMP%\intlMountPoints`). Size approximately = active profile count × average profile size.
+
+## Antivirus Exclusions
+
+When Cloud Cache is enabled, add these exclusions on AVD session hosts:
+
+- **Processes:** `frxsvc.exe`, `frxdrv.sys`, `frxccd.sys`
+- **Paths:** `%ProgramFiles%\FSLogix\Apps\*`, `%TEMP%\intlMountPoints\*`
+- **File types:** `*.VHD`, `*.VHDX`
+
+## Monitoring
+
+Monitor Cloud Cache health via:
+
+- **Event Log:** `Applications and Services Logs > Microsoft > FSLogix > CloudCache > Operational`
+- **Key events:** Provider connection failures (Event ID 49), provider resync (Event ID 50)
+- **Azure Monitor:** Forward FSLogix event logs to Log Analytics for centralized alerting

--- a/src/ansible/inventory/inventory.yml
+++ b/src/ansible/inventory/inventory.yml
@@ -98,7 +98,11 @@ all:
     sofs_fslogix_profile_size_mb: 30000
     sofs_fslogix_volume_type: "VHDX"
     sofs_cloud_cache_enabled: false
-    # sofs_cloud_cache_azure_provider: ""
+    # sofs_cloud_cache_azure_provider: ""  # (deprecated — use providers list)
+    sofs_cloud_cache_providers: []
+    # sofs_cloud_cache_providers:
+    #   - type: "azure"
+    #     connectionString: "DefaultEndpointsProtocol=https;AccountName=stfslogixdr;..."
 
     # --- DNS ---
     sofs_dns_servers:

--- a/src/ansible/molecule/default/molecule.yml
+++ b/src/ansible/molecule/default/molecule.yml
@@ -66,6 +66,7 @@ provisioner:
           sofs_fslogix_profile_size_mb: 10000
           sofs_fslogix_volume_type: "VHDX"
           sofs_cloud_cache_enabled: false
+          sofs_cloud_cache_providers: []
           sofs_dns_servers:
             - "10.0.0.10"
           ansible_connection: local

--- a/src/ansible/playbooks/configure-fslogix.yml
+++ b/src/ansible/playbooks/configure-fslogix.yml
@@ -17,6 +17,8 @@
     fslogix_profile_size_mb: "{{ sofs_fslogix_profile_size_mb | default(30000) | int }}"
     fslogix_volume_type: "{{ sofs_fslogix_volume_type | default('VHDX') }}"
     cloud_cache_enabled: "{{ sofs_cloud_cache_enabled | default(false) | bool }}"
+    guest_volume_layout: "{{ sofs_guest_volume_layout | default('option_a') }}"
+    sofs_shares_list: "{{ sofs_shares | default([]) }}"
 
   tasks:
     - name: Ensure FSLogix Profiles registry key exists
@@ -77,3 +79,45 @@
     - name: Show FSLogix configuration
       ansible.builtin.debug:
         var: fslogix_config.output
+
+    # ---------------------------------------------------------------
+    # Cloud Cache — CCDLocations registry (only when enabled)
+    # ---------------------------------------------------------------
+    - name: Build CCDLocations value for Cloud Cache
+      ansible.builtin.set_fact:
+        _cc_ccd_locations: >-
+          {%- set parts = [] -%}
+          {%- if guest_volume_layout == 'option_a' -%}
+            {%- set _ = parts.append('type=smb,connectionString=\\\\' ~ access_point ~ '\\' ~ share_name) -%}
+          {%- else -%}
+            {%- for s in sofs_shares_list -%}
+              {%- set _ = parts.append('type=smb,connectionString=\\\\' ~ access_point ~ '\\' ~ s.name) -%}
+            {%- endfor -%}
+          {%- endif -%}
+          {%- set providers = sofs_cloud_cache_providers | default([]) -%}
+          {%- if providers | length > 0 -%}
+            {%- for p in providers -%}
+              {%- set _ = parts.append('type=' ~ p.type ~ ',connectionString=' ~ p.connectionString) -%}
+            {%- endfor -%}
+          {%- elif sofs_cloud_cache_azure_provider | default('') | length > 0 -%}
+            {%- set _ = parts.append('type=azure,connectionString=' ~ sofs_cloud_cache_azure_provider) -%}
+          {%- endif -%}
+          {{ parts | join(';') }}
+      when: cloud_cache_enabled
+
+    - name: Set CCDLocations registry value
+      ansible.windows.win_regedit:
+        path: "{{ fslogix_reg_path }}"
+        name: CCDLocations
+        data: "{{ _cc_ccd_locations }}"
+        type: expandstring
+      when:
+        - cloud_cache_enabled
+        - _cc_ccd_locations is defined
+
+    - name: Remove VHDLocations when Cloud Cache is active
+      ansible.windows.win_regedit:
+        path: "{{ fslogix_reg_path }}"
+        name: VHDLocations
+        state: absent
+      when: cloud_cache_enabled

--- a/src/ansible/playbooks/configure-sofs-cluster.yml
+++ b/src/ansible/playbooks/configure-sofs-cluster.yml
@@ -395,19 +395,57 @@
     # -----------------------------------------------------------------
     # Phase 9c: Cloud Cache (optional)
     # -----------------------------------------------------------------
-    - name: "Phase 9c — Configure Cloud Cache provider"
-      ansible.windows.win_powershell:
-        script: |
-          # Cloud Cache configuration is applied via FSLogix GPO / registry
-          # This task creates the CCDLocations registry value
-          $regPath = 'HKLM:\SOFTWARE\FSLogix\Profiles'
-          if (-not (Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }
-          Set-ItemProperty -Path $regPath -Name 'CCDLocations' `
-              -Value '{{ sofs_cloud_cache_azure_provider | default("") }}' -Type String
-          Write-Output "Cloud Cache CCDLocations configured"
+    # Builds CCDLocations from auto-generated SMB providers (one per share)
+    # plus any additional providers from sofs_cloud_cache_providers[].
+    # Falls back to legacy sofs_cloud_cache_azure_provider if providers
+    # list is empty.
+    - name: "Phase 9c — Build CCDLocations value"
+      ansible.builtin.set_fact:
+        _cc_smb_parts: >-
+          {%- if guest_volume_layout == 'option_a' -%}
+            type=smb,connectionString=\\{{ access_point }}\{{ share_name }}
+          {%- else -%}
+            {{ sofs_shares_list | map(attribute='name') | map('regex_replace', '^(.*)$', 'type=smb,connectionString=\\\\' ~ access_point ~ '\\\\\\1') | join(';') }}
+          {%- endif -%}
+        _cc_extra_parts: >-
+          {%- if (sofs_cloud_cache_providers | default([])) | length > 0 -%}
+            {{ sofs_cloud_cache_providers | map('regex_replace', '^.*$', '') }}
+          {%- endif -%}
       when:
         - inventory_hostname == groups['sofs_nodes'][0]
         - sofs_cloud_cache_enabled | default(false) | bool
+
+    - name: "Phase 9c — Generate CCDLocations from providers"
+      ansible.builtin.set_fact:
+        _cc_ccd_locations: >-
+          {%- set parts = [] -%}
+          {%- if guest_volume_layout == 'option_a' -%}
+            {%- set _ = parts.append('type=smb,connectionString=\\\\' ~ access_point ~ '\\' ~ share_name) -%}
+          {%- else -%}
+            {%- for s in sofs_shares_list -%}
+              {%- set _ = parts.append('type=smb,connectionString=\\\\' ~ access_point ~ '\\' ~ s.name) -%}
+            {%- endfor -%}
+          {%- endif -%}
+          {%- set providers = sofs_cloud_cache_providers | default([]) -%}
+          {%- if providers | length > 0 -%}
+            {%- for p in providers -%}
+              {%- set _ = parts.append('type=' ~ p.type ~ ',connectionString=' ~ p.connectionString) -%}
+            {%- endfor -%}
+          {%- elif sofs_cloud_cache_azure_provider | default('') | length > 0 -%}
+            {%- set _ = parts.append('type=azure,connectionString=' ~ sofs_cloud_cache_azure_provider) -%}
+          {%- endif -%}
+          {{ parts | join(';') }}
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - sofs_cloud_cache_enabled | default(false) | bool
+
+    - name: "Phase 9c — Display CCDLocations value"
+      ansible.builtin.debug:
+        msg: "CCDLocations: {{ _cc_ccd_locations }}"
+      when:
+        - inventory_hostname == groups['sofs_nodes'][0]
+        - sofs_cloud_cache_enabled | default(false) | bool
+        - _cc_ccd_locations is defined
 
     # -----------------------------------------------------------------
     # Phase 11: Validation

--- a/src/arm/azuredeploy.json
+++ b/src/arm/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "13515824846979693699"
+      "templateHash": "7025526361703900475"
     }
   },
   "parameters": {
@@ -340,7 +340,14 @@
       "type": "securestring",
       "defaultValue": "",
       "metadata": {
-        "description": "Azure Blob connection string for Cloud Cache provider"
+        "description": "(Deprecated) Azure Blob connection string — use cloudCacheProviders instead"
+      }
+    },
+    "cloudCacheProviders": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Additional Cloud Cache providers for CCDLocations (SMB providers auto-generated)"
       }
     },
     "dnsServers": {

--- a/src/arm/azuredeploy.parameters.example.json
+++ b/src/arm/azuredeploy.parameters.example.json
@@ -147,6 +147,9 @@
     "cloudCacheAzureProvider": {
       "value": ""
     },
+    "cloudCacheProviders": {
+      "value": []
+    },
     "dnsServers": {
       "value": ["10.0.1.10", "10.0.1.11"]
     },

--- a/src/bicep/main.bicep
+++ b/src/bicep/main.bicep
@@ -217,8 +217,11 @@ param fslogixVolumeType string = 'VHDX'
 param cloudCacheEnabled bool = false
 
 @secure()
-@description('Azure Blob connection string for Cloud Cache provider')
+@description('(Deprecated) Azure Blob connection string — use cloudCacheProviders instead')
 param cloudCacheAzureProvider string = ''
+
+@description('Additional Cloud Cache providers for CCDLocations (SMB providers auto-generated)')
+param cloudCacheProviders array = []
 
 // ---------------------------------------------------------------------------
 // Parameters — DNS

--- a/src/bicep/main.bicepparam
+++ b/src/bicep/main.bicepparam
@@ -93,7 +93,10 @@ param fslogixEnabled = true
 param fslogixProfileSizeMb = 30000
 param fslogixVolumeType = 'VHDX'
 param cloudCacheEnabled = false
-// param cloudCacheAzureProvider = ''
+// param cloudCacheAzureProvider = ''       // deprecated — use cloudCacheProviders
+// param cloudCacheProviders = [
+//   { type: 'azure', connectionString: '' }
+// ]
 
 // --- DNS ---
 param dnsServers = ['10.0.1.10', '10.0.1.11']

--- a/src/powershell/deploy/Configure-SOFS-Cluster.ps1
+++ b/src/powershell/deploy/Configure-SOFS-Cluster.ps1
@@ -1534,8 +1534,12 @@ if ($FSRMQuotaSizeMB -gt 0) {
 # PHASE 9c: Cloud Cache Registry Configuration
 # When fslogix.cloud_cache.enabled = true, outputs the recommended
 # CCDLocations registry value for AVD session hosts. Cloud Cache writes
-# profile containers to both the SOFS share and an Azure Blob provider,
-# providing DR and reduced SOFS load.
+# profile containers to both the SOFS share(s) and additional providers
+# (e.g. Azure Blob for DR), providing multi-site redundancy.
+#
+# Provider resolution order:
+#   1. fslogix.cloud_cache.providers[] array (preferred)
+#   2. fslogix.cloud_cache.azure_provider string (legacy fallback)
 # ===========================================================================
 
 $CloudCacheEnabled = ($FSLogixConfig -and $FSLogixConfig.cloud_cache -and $FSLogixConfig.cloud_cache.enabled)
@@ -1543,18 +1547,28 @@ $CloudCacheEnabled = ($FSLogixConfig -and $FSLogixConfig.cloud_cache -and $FSLog
 if ($CloudCacheEnabled) {
     Write-Log "Phase 9c — Cloud Cache Configuration" "HEADER"
 
-    $AzureProvider = if ($FSLogixConfig.cloud_cache.azure_provider -and $FSLogixConfig.cloud_cache.azure_provider -ne "") {
-        $FSLogixConfig.cloud_cache.azure_provider
-    } else { $null }
-
-    # Build CCDLocations value — SMB provider for each share + optional Azure Blob provider
+    # Build CCDLocations value — SMB provider for each share + additional providers
     $ccdParts = @()
     foreach ($sn in $phase8ShareNames) {
         $ccdParts += "type=smb,connectionString=\\$SOFSAccessPoint\$sn"
     }
-    if ($AzureProvider) {
-        $ccdParts += "type=azure,connectionString=$AzureProvider"
+
+    # Resolve additional providers from config
+    $providers = $FSLogixConfig.cloud_cache.providers
+    if ($providers -and $providers.Count -gt 0) {
+        foreach ($p in $providers) {
+            $ccdParts += "type=$($p.type),connectionString=$($p.connectionString)"
+        }
+    } else {
+        # Legacy fallback: single azure_provider string
+        $AzureProvider = if ($FSLogixConfig.cloud_cache.azure_provider -and $FSLogixConfig.cloud_cache.azure_provider -ne "") {
+            $FSLogixConfig.cloud_cache.azure_provider
+        } else { $null }
+        if ($AzureProvider) {
+            $ccdParts += "type=azure,connectionString=$AzureProvider"
+        }
     }
+
     $ccdLocations = $ccdParts -join ";"
 
     Write-Log "  CCDLocations value for AVD session hosts:" "HEADER"
@@ -1570,9 +1584,10 @@ if ($CloudCacheEnabled) {
         Write-Log "  Value data:   $ccdLocations" "INFO"
         Write-Log "  PowerShell to apply on each AVD session host:" "INFO"
         Write-Log "    Set-ItemProperty -Path 'HKLM:\SOFTWARE\FSLogix\Profiles' -Name 'CCDLocations' -Value '$ccdLocations' -Type ExpandString" "INFO"
-        if (-not $AzureProvider) {
-            Write-Log "  [WARN] No Azure Blob provider configured — Cloud Cache will only use SMB." "WARN"
-            Write-Log "  Set fslogix.cloud_cache.azure_provider in config for DR redundancy." "WARN"
+        $hasExternalProvider = ($providers -and $providers.Count -gt 0) -or $AzureProvider
+        if (-not $hasExternalProvider) {
+            Write-Log "  [WARN] No external provider configured — Cloud Cache will only use SMB." "WARN"
+            Write-Log "  Add providers to fslogix.cloud_cache.providers[] in config for DR redundancy." "WARN"
         }
     }
     Write-Log "Cloud Cache configuration guidance generated." "PASS"

--- a/src/terraform/ansible-inventory.tf
+++ b/src/terraform/ansible-inventory.tf
@@ -61,6 +61,7 @@ resource "local_sensitive_file" "ansible_inventory" {
     fslogix_profile_size_mb     = var.fslogix_profile_size_mb
     fslogix_volume_type         = var.fslogix_volume_type
     cloud_cache_enabled         = var.cloud_cache_enabled
+    cloud_cache_providers       = var.cloud_cache_providers
     dns_servers        = var.dns_servers
     winrm_transport    = var.winrm_transport
     vm_hosts           = local.ansible_vm_hosts

--- a/src/terraform/templates/inventory.yml.tftpl
+++ b/src/terraform/templates/inventory.yml.tftpl
@@ -85,6 +85,15 @@ all:
     sofs_fslogix_profile_size_mb: ${fslogix_profile_size_mb}
     sofs_fslogix_volume_type: "${fslogix_volume_type}"
     sofs_cloud_cache_enabled: ${cloud_cache_enabled}
+%{ if length(cloud_cache_providers) > 0 ~}
+    sofs_cloud_cache_providers:
+%{ for p in cloud_cache_providers ~}
+      - type: "${p.type}"
+        connectionString: "${p.connectionString}"
+%{ endfor ~}
+%{ else ~}
+    sofs_cloud_cache_providers: []
+%{ endif ~}
 
     # --- DNS servers ---
 %{ if length(dns_servers) > 0 ~}

--- a/src/terraform/terraform.tfvars.example
+++ b/src/terraform/terraform.tfvars.example
@@ -104,7 +104,10 @@ fslogix_enabled         = true
 fslogix_profile_size_mb = 30000
 fslogix_volume_type     = "VHDX"
 cloud_cache_enabled     = false
-# cloud_cache_azure_provider = ""   # Azure Blob connection string (if enabled)
+# cloud_cache_azure_provider = ""            # (deprecated — use cloud_cache_providers)
+# cloud_cache_providers = [
+#   { type = "azure", connectionString = "DefaultEndpointsProtocol=https;AccountName=stfslogixdr;..." }
+# ]
 
 # --- VM IP Addresses (keyed by zero-padded index) ---
 vm_ips = {

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -417,10 +417,20 @@ variable "cloud_cache_enabled" {
 }
 
 variable "cloud_cache_azure_provider" {
-  description = "Azure Blob connection string for Cloud Cache provider"
+  description = "(Deprecated) Azure Blob connection string for Cloud Cache — use cloud_cache_providers instead"
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "cloud_cache_providers" {
+  description = "Ordered list of additional Cloud Cache providers for CCDLocations (SMB providers auto-generated from shares)"
+  type = list(object({
+    type             = string
+    connectionString = string
+  }))
+  default   = []
+  sensitive = true
 }
 
 variable "s2d_volume_name" {

--- a/tests/Test-SOFSDeployment.Tests.ps1
+++ b/tests/Test-SOFSDeployment.Tests.ps1
@@ -94,6 +94,16 @@ fslogix:
   volume_type: "VHDX"
   flip_flop_name: true
   delete_local_profile: true
+  cloud_cache:
+    enabled: true
+    azure_provider: "type=smb,connectionString=\\\\TestSOFS.test.local\\Profiles"
+    providers:
+      - name: "primary"
+        type: "smb"
+        connection_string: "\\\\TestSOFS.test.local\\Profiles"
+      - name: "dr"
+        type: "smb"
+        connection_string: "\\\\DR-SOFS.test.local\\Profiles"
 tags:
   project: "SOFS"
   environment: "test"
@@ -880,6 +890,9 @@ Describe "Cloud Cache Configuration" {
     It "cloud_cache.enabled is a boolean" {
         $sol.fslogix.cloud_cache.enabled | Should -BeOfType [bool]
     }
+    It "cloud_cache.providers array exists" {
+        $sol.fslogix.cloud_cache.providers | Should -Not -BeNullOrEmpty -Because "providers array must be defined (even if empty)"
+    }
     It "Generates correct CCDLocations for SMB-only" {
         $sofsName  = $sol.sofs.role_name
         $shareName = $sol.sofs.share_name
@@ -888,7 +901,7 @@ Describe "Cloud Cache Configuration" {
         $ccd | Should -Match "type=smb"
         $ccd | Should -Match "\\\\$sofsName\\$shareName"
     }
-    It "Generates correct CCDLocations with Azure provider" {
+    It "Generates correct CCDLocations with Azure provider (legacy)" {
         $sofsName  = $sol.sofs.role_name
         $shareName = $sol.sofs.share_name
         $azProvider = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=key;"
@@ -900,5 +913,42 @@ Describe "Cloud Cache Configuration" {
         $ccd | Should -Match "type=smb"
         $ccd | Should -Match "type=azure"
         $ccd | Should -Match "AccountName=test"
+    }
+    It "Generates correct CCDLocations from multi-provider array" {
+        $sofsName  = $sol.sofs.role_name
+        $shareName = $sol.sofs.share_name
+        $providers = @(
+            @{ type = "azure"; connectionString = "DefaultEndpointsProtocol=https;AccountName=stdr01;AccountKey=k1;" },
+            @{ type = "smb2";  connectionString = "\\secondary-sofs\Profiles" }
+        )
+        $ccdParts = @("type=smb,connectionString=\\$sofsName\$shareName")
+        foreach ($p in $providers) {
+            $ccdParts += "type=$($p.type),connectionString=$($p.connectionString)"
+        }
+        $ccd = $ccdParts -join ";"
+        $ccd | Should -Match "type=smb,connectionString=\\\\$sofsName"
+        $ccd | Should -Match "type=azure,connectionString=.*AccountName=stdr01"
+        $ccd | Should -Match "type=smb2,connectionString=\\\\secondary-sofs"
+        ($ccd.Split(';')).Count | Should -Be 3
+    }
+    It "Providers array takes precedence over legacy azure_provider" {
+        # When providers[] is non-empty, azure_provider is ignored
+        $providers = @(
+            @{ type = "azure"; connectionString = "AccountName=fromarray" }
+        )
+        $legacyProvider = "AccountName=fromlegacy"
+        $ccdParts = @("type=smb,connectionString=\\sofs\share")
+        if ($providers.Count -gt 0) {
+            foreach ($p in $providers) {
+                $ccdParts += "type=$($p.type),connectionString=$($p.connectionString)"
+            }
+        } else {
+            if ($legacyProvider) {
+                $ccdParts += "type=azure,connectionString=$legacyProvider"
+            }
+        }
+        $ccd = $ccdParts -join ";"
+        $ccd | Should -Match "fromarray"
+        $ccd | Should -Not -Match "fromlegacy"
     }
 }


### PR DESCRIPTION
## Summary

Implements **Issue #66 — Cloud Cache DR support** (part of Epic #59).

### Changes across all 5 tools

| Component | Change |
|-----------|--------|
| **Config** | Added `cloud_cache.providers[]` array to `variables.example.yml` — supports named multi-provider entries with type + connection_string |
| **Schema** | Added `providers` array validation to `variables.schema.json` |
| **PowerShell** | Updated Phase 9c in `Configure-SOFS-Cluster.ps1` to build CCDLocations from `providers[]` array with multi-provider support |
| **Ansible** | Updated `configure-sofs-cluster.yml` Phase 9c + `configure-fslogix.yml` for providers-based CCDLocations on AVD session hosts |
| **Terraform** | Added `cloud_cache_providers` variable, passed through inventory template |
| **Bicep** | Added `cloudCacheProviders` param array |
| **ARM** | Recompiled from Bicep with new `cloudCacheProviders` parameter |

### Tests

- Pester: Added `providers` array to test fixture YAML, updated Cloud Cache test suite (suite 23)
- Molecule: Added `cloud_cache_providers` to test inventory

### Documentation

- Added `docs/architecture/cloud-cache.md` — covers multi-provider DR design, failover behavior, and CCDLocations string format

Closes #66