### PR TITLE
fix: close audit gaps from epic #59 review

### DIFF
--- a/config/schema/variables.schema.json
+++ b/config/schema/variables.schema.json
@@ -197,7 +197,7 @@
     },
     "fslogix": {
       "type": "object",
-      "required": ["enabled"],
+      "required": ["enabled", "profile_size_mb", "volume_type"],
       "properties": {
         "enabled": { "type": "boolean" },
         "profile_size_mb": { "type": "integer" },

--- a/src/ansible/inventory/inventory.yml
+++ b/src/ansible/inventory/inventory.yml
@@ -127,7 +127,13 @@ all:
         azl-node-02:
           ansible_host: 10.0.0.2
 
-    # SOFS guest VMs
+    # SOFS guest VMs — add/remove hosts to match sofs_vm_count (2-16).
+    # Each host must be listed explicitly with its IP. The sofs_vm_count
+    # variable above drives playbook loops; the host list here must
+    # contain at least that many entries.
+    #
+    # For dynamic inventories (e.g. Terraform-generated), see:
+    #   src/terraform/ansible-inventory.tf
     sofs_nodes:
       hosts:
         SOFS-01:
@@ -136,6 +142,12 @@ all:
           ansible_host: 192.168.211.52
         SOFS-03:
           ansible_host: 192.168.211.53
+        # Add more hosts for 4+ node scenarios:
+        # SOFS-04:
+        #   ansible_host: 192.168.211.54
+        # ...
+        # SOFS-16:
+        #   ansible_host: 192.168.211.66
 
     # AVD session hosts (for FSLogix registry config)
     avd_session_hosts:

--- a/src/ansible/molecule/default/converge.yml
+++ b/src/ansible/molecule/default/converge.yml
@@ -10,5 +10,14 @@
     sofs_admin_password: "TestPass123!"
     sofs_domain_join_password: "TestPass123!"
 
+- name: "Verify configure-sofs-cluster.yml syntax"
+  ansible.builtin.import_playbook: ../../playbooks/configure-sofs-cluster.yml
+  vars:
+    sofs_admin_password: "TestPass123!"
+    sofs_domain_join_password: "TestPass123!"
+
+- name: "Verify configure-sofs.yml syntax"
+  ansible.builtin.import_playbook: ../../playbooks/configure-sofs.yml
+
 - name: "Verify configure-fslogix.yml syntax"
   ansible.builtin.import_playbook: ../../playbooks/configure-fslogix.yml


### PR DESCRIPTION
## Summary

Closes audit gaps found during Epic #59 completion review.

### Fixes

| Gap | File | Change |
|-----|------|--------|
| **#63 — Molecule coverage** | `src/ansible/molecule/default/converge.yml` | Added `configure-sofs-cluster.yml` and `configure-sofs.yml` imports so all 4 playbooks are syntax-tested |
| **#63 — Inventory scaling** | `src/ansible/inventory/inventory.yml` | Added guidance comments and commented-out examples for scaling to 4–16 nodes |
| **#60 — Schema strictness** | `config/schema/variables.schema.json` | `fslogix` schema now requires `profile_size_mb` and `volume_type` in addition to `enabled` |